### PR TITLE
Add link warning to bottom of page

### DIFF
--- a/nko/index.html
+++ b/nko/index.html
@@ -50,7 +50,7 @@
 </div>
 
 
-
+<div id="linkWarning"><span id="closeLinkWarning" onClick="this.parentNode.style.display='none'">X</span> Some links on this page point to repositories or pages to which information will be added over time. Initially, the link may produce no results, but as issues, tests, etc. are created they will show up.</div>
 
 
 

--- a/nko/local.css
+++ b/nko/local.css
@@ -148,5 +148,27 @@ dl.reslinks {
 
 
 
+#linkWarning {
+    position:fixed;
+    bottom:0;
+    margin-inline: 2.5%;
+    background-color: antiquewhite;
+    border-top-left-radius: 1em;
+    border-top-right-radius: 1em;
+    font-size: 90%;
+    padding: .5em;
+    z-index: 2000;
+    }
+#closeLinkWarning {
+    float:right;
+    font-size:120%;
+    margin-inline:1em;
+    cursor:pointer;
+    color: #999;
+    }
+
+
+
+
 
 


### PR DESCRIPTION
This is to warn people that clicking on links may not produce results at the moment, but may do so in the future.  The aim is to reduce surprise and possible frustration when clicking on links to repos or pages doesn't produce relevant results.

I'd like to retrofit this to all the new format lreq docs this week, if approved, so i'd appreciate a quick review.

[Preview](https://deploy-preview-46--afrlreq.netlify.app/nko/index.html)